### PR TITLE
HDDS-3755 Fix the wrong parameters sequence within allocateContainer.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -284,8 +284,8 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       throws IOException {
     ContainerWithPipeline containerWithPipeline = impl
         .allocateContainer(
-            request.getStorageClass(),
-            request.getOwner());
+            request.getOwner(),
+            request.getStorageClass());
     return ContainerResponseProto.newBuilder()
         .setContainerWithPipeline(containerWithPipeline.getProtobuf())
         .setErrorCode(ContainerResponseProto.Error.success)

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -231,8 +231,8 @@ public class ContainerOperationClient implements ScmClient {
     try {
       // allocate container on SCM.
       ContainerWithPipeline containerWithPipeline =
-          storageContainerLocationClient.allocateContainer(storageClass,
-              owner);
+          storageContainerLocationClient.allocateContainer(owner,
+              storageClass);
       Pipeline pipeline = containerWithPipeline.getPipeline();
       // connect to pipeline leader and allocate container on leader datanode.
       client = xceiverClientManager.acquireClient(pipeline);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerStateMachineIdempotency.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestContainerStateMachineIdempotency.java
@@ -87,8 +87,8 @@ public class TestContainerStateMachineIdempotency {
   public void testContainerStateMachineIdempotency() throws Exception {
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(
-            StaticStorageClassRegistry.REDUCED_REDUNDANCY.getName(),
-            OzoneConsts.OZONE);
+            OzoneConsts.OZONE,
+            StaticStorageClassRegistry.REDUCED_REDUNDANCY.getName());
     long containerID = container.getContainerInfo().getContainerID();
     Pipeline pipeline = container.getPipeline();
     XceiverClientSpi client = xceiverClientManager.acquireClient(pipeline);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/Test2WayCommitInRatis.java
@@ -144,7 +144,8 @@ public class Test2WayCommitInRatis {
 
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(
-            StaticStorageClassRegistry.STANDARD.getName(), OzoneConsts.OZONE);
+            OzoneConsts.OZONE,
+            StaticStorageClassRegistry.STANDARD.getName());
     XceiverClientSpi xceiverClient = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, xceiverClient.getRefcount());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCommitWatcher.java
@@ -167,7 +167,8 @@ public class TestCommitWatcher {
     XceiverClientManager clientManager = new XceiverClientManager(conf);
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(
-            StaticStorageClassRegistry.STANDARD.getName(), OzoneConsts.OZONE);
+            OzoneConsts.OZONE,
+            StaticStorageClassRegistry.STANDARD.getName());
     Pipeline pipeline = container.getPipeline();
     long containerId = container.getContainerInfo().getContainerID();
     XceiverClientSpi xceiverClient = clientManager.acquireClient(pipeline);
@@ -244,7 +245,8 @@ public class TestCommitWatcher {
     XceiverClientManager clientManager = new XceiverClientManager(conf);
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(
-            StaticStorageClassRegistry.STANDARD.getName(), OzoneConsts.OZONE);
+            OzoneConsts.OZONE,
+            StaticStorageClassRegistry.STANDARD.getName());
     Pipeline pipeline = container.getPipeline();
     long containerId = container.getContainerInfo().getContainerID();
     XceiverClientSpi xceiverClient = clientManager.acquireClient(pipeline);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestWatchForCommit.java
@@ -242,7 +242,8 @@ public class TestWatchForCommit {
     XceiverClientManager clientManager = new XceiverClientManager(conf);
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(
-            StaticStorageClassRegistry.STANDARD.getName(), OzoneConsts.OZONE);
+            OzoneConsts.OZONE,
+            StaticStorageClassRegistry.STANDARD.getName());
     XceiverClientSpi xceiverClient = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, xceiverClient.getRefcount());
@@ -285,7 +286,8 @@ public class TestWatchForCommit {
 
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(
-            StaticStorageClassRegistry.STANDARD.getName(), OzoneConsts.OZONE);
+            OzoneConsts.OZONE,
+            StaticStorageClassRegistry.STANDARD.getName());
     XceiverClientSpi xceiverClient = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, xceiverClient.getRefcount());
@@ -328,7 +330,8 @@ public class TestWatchForCommit {
     XceiverClientManager clientManager = new XceiverClientManager(conf);
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(
-            StaticStorageClassRegistry.STANDARD.getName(), OzoneConsts.OZONE);
+            OzoneConsts.OZONE,
+            StaticStorageClassRegistry.STANDARD.getName());
     XceiverClientSpi xceiverClient = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, xceiverClient.getRefcount());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
@@ -75,10 +75,10 @@ public class TestAllocateContainer {
   public void testAllocate() throws Exception {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
+            OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)),
-            OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)));
     Assert.assertNotNull(container);
     Assert.assertNotNull(container.getPipeline().getFirstNode());
 
@@ -88,8 +88,9 @@ public class TestAllocateContainer {
   public void testAllocateNull() throws Exception {
     thrown.expect(NullPointerException.class);
     storageContainerLocationClient.allocateContainer(
+        null,
         StorageClassConverter.convert(null,
             SCMTestUtils.getReplicationFactor(conf),
-            SCMTestUtils.getReplicationType(conf)), null);
+            SCMTestUtils.getReplicationType(conf)));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
@@ -170,7 +170,7 @@ public class TestContainerSmallFile {
             StorageClassConverter.convert(
                 null, HddsProtos.ReplicationFactor.ONE,
                 SCMTestUtils.getReplicationType(ozoneConfig))
-            );
+        );
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
@@ -89,10 +89,10 @@ public class TestContainerSmallFile {
   public void testAllocateWrite() throws Exception {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
+            OzoneConsts.OZONE,
             StorageClassConverter.convert(
                 null, HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(ozoneConfig)),
-            OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(ozoneConfig)));
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,
@@ -113,10 +113,10 @@ public class TestContainerSmallFile {
   public void testInvalidBlockRead() throws Exception {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
+            OzoneConsts.OZONE,
             StorageClassConverter.convert(
                 null, HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(ozoneConfig)),
-            OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(ozoneConfig)));
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,
@@ -138,10 +138,10 @@ public class TestContainerSmallFile {
     long nonExistContainerID = 8888L;
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
+            OzoneConsts.OZONE,
             StorageClassConverter.convert(
                 null, HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(ozoneConfig)),
-            OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(ozoneConfig)));
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,
@@ -166,10 +166,11 @@ public class TestContainerSmallFile {
   public void testReadWriteWithBCSId() throws Exception {
     ContainerWithPipeline container =
         storageContainerLocationClient.allocateContainer(
+            OzoneConsts.OZONE,
             StorageClassConverter.convert(
                 null, HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(ozoneConfig)),
-            OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(ozoneConfig))
+            );
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestGetCommittedBlockLengthAndPutKey.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestGetCommittedBlockLengthAndPutKey.java
@@ -160,7 +160,7 @@ public class TestGetCommittedBlockLengthAndPutKey {
   public void tesPutKeyResposne() throws Exception {
     ContainerProtos.PutBlockResponseProto response;
     ContainerWithPipeline container = storageContainerLocationClient
-        .allocateContainer("REDUCED", OzoneConsts.OZONE);
+        .allocateContainer(OzoneConsts.OZONE, "REDUCED");
     long containerID = container.getContainerInfo().getContainerID();
     Pipeline pipeline = container.getPipeline();
     XceiverClientSpi client = xceiverClientManager.acquireClient(pipeline);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
@@ -93,10 +93,10 @@ public class TestXceiverClientManager {
 
     ContainerWithPipeline container1 = storageContainerLocationClient
         .allocateContainer(
+            OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)),
-            OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)));
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
@@ -136,10 +136,10 @@ public class TestXceiverClientManager {
 
     ContainerWithPipeline container1 =
         storageContainerLocationClient.allocateContainer(
+            OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
                 HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(conf)),
-            OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)));
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
@@ -198,10 +198,10 @@ public class TestXceiverClientManager {
 
     ContainerWithPipeline container1 =
         storageContainerLocationClient.allocateContainer(
+            OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)),
-            OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)));
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
@@ -253,10 +253,10 @@ public class TestXceiverClientManager {
     // client is added in cache
     ContainerWithPipeline container1 =
         storageContainerLocationClient.allocateContainer(
+            OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)),
-            OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)));
     XceiverClientSpi client1 =
         clientManager.acquireClient(container1.getPipeline());
     clientManager.acquireClient(container1.getPipeline());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientMetrics.java
@@ -97,11 +97,11 @@ public class TestXceiverClientMetrics {
 
     ContainerWithPipeline container = storageContainerLocationClient
         .allocateContainer(
+            OzoneConsts.OZONE,
             StorageClassConverter.convert(
                 null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)),
-            OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)));
     XceiverClientSpi client = clientManager
         .acquireClient(container.getPipeline());
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1019,8 +1019,8 @@ message MultipartKeyInfo {
     required uint64 creationTime = 2;
     // TODO(baoloongmao): Remove these two future
     // deprecated, please use storageClass instead
-    required hadoop.hdds.ReplicationType type = 3;
-    required hadoop.hdds.ReplicationFactor factor = 4;
+    optional hadoop.hdds.ReplicationType type = 3;
+    optional hadoop.hdds.ReplicationFactor factor = 4;
     repeated PartKeyInfo partKeyInfoList = 5;
     optional uint64 objectID = 6;
     optional uint64 updateID = 7;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the wrong parameters sequence within allocateContainer. The storageClass parameter should be the second parameter.  

## What is the link to the Apache JIRA

HDDS-3755

## How was this patch tested?

CI check.