### PR TITLE
Use StorageClass class to replace the string within ozone service.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StorageClassConverter.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/StorageClassConverter.java
@@ -33,7 +33,7 @@ public final class StorageClassConverter {
   private StorageClassConverter() {
   }
 
-  public static String convert(
+  public static StorageClass convert(
       ConfigurationSource conf,
       ReplicationFactor factor,
       ReplicationType type
@@ -50,22 +50,22 @@ public final class StorageClassConverter {
     }
 
     if (factor == ReplicationFactor.THREE && type == ReplicationType.RATIS) {
-      return StaticStorageClassRegistry.STANDARD.getName();
+      return StaticStorageClassRegistry.STANDARD;
     }
 
     if (factor == ReplicationFactor.ONE && type == ReplicationType.RATIS) {
-      return StaticStorageClassRegistry.REDUCED_REDUNDANCY.getName();
+      return StaticStorageClassRegistry.REDUCED_REDUNDANCY;
     }
 
     if (factor == ReplicationFactor.ONE
         && type == ReplicationType.STAND_ALONE) {
-      return StaticStorageClassRegistry.LEGACY.getName();
+      return StaticStorageClassRegistry.LEGACY;
     }
 
-    return StaticStorageClassRegistry.STANDARD.getName();
+    return StaticStorageClassRegistry.STANDARD;
   }
 
-  public static String convert(OzoneConfiguration conf,
+  public static StorageClass convert(OzoneConfiguration conf,
       org.apache.hadoop.hdds.client.ReplicationFactor factor,
       org.apache.hadoop.hdds.client.ReplicationType type) {
     ReplicationFactor replicationFactor =
@@ -74,7 +74,7 @@ public final class StorageClassConverter {
     return convert(conf, replicationFactor, replicationType);
   }
 
-  public static String convert(OzoneConfiguration conf,
+  public static StorageClass convert(OzoneConfiguration conf,
       org.apache.hadoop.hdds.client.ReplicationFactor factor,
       ReplicationType type) {
     ReplicationFactor replicationFactor =
@@ -82,7 +82,7 @@ public final class StorageClassConverter {
     return convert(conf, replicationFactor, type);
   }
 
-  public static String convert(Pipeline pipeline) {
+  public static StorageClass convert(Pipeline pipeline) {
     return convert(null, pipeline.getFactor(), pipeline.getType());
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Comparator;
 
+import org.apache.hadoop.hdds.StorageClass;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
@@ -54,7 +55,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
   private ReplicationFactor replicationFactor;
   @Deprecated
   private ReplicationType replicationType;
-  private String storageClass;
+  private StorageClass storageClass;
   private long usedBytes;
   private long numberOfKeys;
   private Instant lastUsed;
@@ -115,7 +116,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
       long sequenceId,
       ReplicationFactor replicationFactor,
       ReplicationType repType,
-      String storageClass) {
+      StorageClass storageClass) {
     this.containerID = containerID;
     this.pipelineID = pipelineID;
     this.usedBytes = usedBytes;
@@ -229,7 +230,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     return replicationType;
   }
 
-  public String getStorageClass() {
+  public StorageClass getStorageClass() {
     return storageClass;
   }
 
@@ -248,7 +249,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
         .setContainerID(getContainerID())
         .setDeleteTransactionId(getDeleteTransactionId())
         .setPipelineID(getPipelineID().getProtobuf())
-        .setStorageClass(getStorageClass())
+        .setStorageClass(getStorageClass().getName())
         .setOwner(getOwner())
         .build();
   }
@@ -400,7 +401,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     throw new IOException(SERIALIZATION_ERROR_MSG);
   }
 
-  public void setStorageClass(String sc) {
+  public void setStorageClass(StorageClass sc) {
     this.storageClass = sc;
   }
 
@@ -419,7 +420,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     private PipelineID pipelineID;
     private ReplicationFactor replicationFactor;
     private ReplicationType replicationType;
-    private String storageClass;
+    private StorageClass storageClass;
 
     public Builder setReplicationType(
         ReplicationType repType) {
@@ -478,7 +479,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
       return this;
     }
 
-    public Builder setStorageClass(String sc) {
+    public Builder setStorageClass(StorageClass sc) {
       this.storageClass = sc;
       return this;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManager.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.hadoop.hdds.StorageClass;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
@@ -46,7 +47,7 @@ public interface BlockManager extends Closeable,
    */
   AllocatedBlock allocateBlock(
       long size,
-      String storageClass,
+      StorageClass storageClass,
       String owner,
       ExcludeList excludeList) throws IOException;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManager.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.hadoop.hdds.StorageClass;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 
@@ -102,7 +103,7 @@ public interface ContainerManager extends Closeable {
    * @throws IOException
    */
   ContainerInfo allocateContainer(
-      String storageClass,
+      StorageClass storageClass,
       String owner)
       throws IOException;
 
@@ -171,7 +172,7 @@ public interface ContainerManager extends Closeable {
    * @return ContainerInfo for the matching container.
    */
   ContainerInfo getMatchingContainer(long size, String owner,
-      String storageClass,
+      StorageClass storageClass,
       Pipeline pipeline);
 
   /**
@@ -187,7 +188,7 @@ public interface ContainerManager extends Closeable {
    */
   ContainerInfo getMatchingContainer(long size,
       String owner,
-      String storageClass,
+      StorageClass storageClass,
       Pipeline pipeline,
       Set<ContainerID> excludedContainerIDS);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -454,7 +454,7 @@ public class ContainerStateManager {
         final ContainerInfo containerInfo = containers.getContainerInfo(id);
         if (containerInfo.getUsedBytes() + size <= this.containerSize
             && storageClass.getName().equals(
-                containerInfo.getStorageClass())) {
+                containerInfo.getStorageClass().getName())) {
           containerInfo.updateLastUsedTime();
           return containerInfo;
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -26,10 +26,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.hadoop.hdds.StaticStorageClassRegistry;
 import org.apache.hadoop.hdds.StorageClass;
 import org.apache.hadoop.hdds.StorageClass.OpenStateConfiguration;
-import org.apache.hadoop.hdds.StorageClassRegistry;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -125,10 +123,6 @@ public class ContainerStateManager {
   private final AtomicLong containerCount;
   private final AtomicLongMap<LifeCycleState> containerStateCount =
       AtomicLongMap.create();
-
-  // TODO(baoloongmao): assign this froms configuration
-  private StorageClassRegistry storageClassRegistry =
-      new StaticStorageClassRegistry();
 
   /**
    * Constructs a Container State Manager that tracks all containers owned by
@@ -247,18 +241,15 @@ public class ContainerStateManager {
    * Allocates a new container based on the type, replication etc.
    *
    * @param pipelineManager -- Pipeline Manager class.
-   * @param storageClassName    -- storageClass for the container.
+   * @param storageClass    -- storageClass for the container.
    * @return ContainerWithPipeline
    * @throws IOException on Failure.
    */
   ContainerInfo allocateContainer(
       final PipelineManager pipelineManager,
-      String storageClassName,
+      StorageClass storageClass,
       final String owner)
       throws IOException {
-
-    final StorageClass storageClass =
-        storageClassRegistry.getStorageClass(storageClassName);
 
     final OpenStateConfiguration openState =
         storageClass.getOpenStateConfiguration();
@@ -274,8 +265,9 @@ public class ContainerStateManager {
 
     boolean bgCreateOne = (type == ReplicationType.RATIS) && replicationFactor
         == ReplicationFactor.ONE && autoCreateRatisOne;
-    boolean bgCreateThree = (type == ReplicationType.RATIS) && replicationFactor
-        == ReplicationFactor.THREE;
+    boolean bgCreateThree =
+        (type == ReplicationType.RATIS) && replicationFactor
+            == ReplicationFactor.THREE;
 
     if (!pipelines.isEmpty() && (bgCreateOne || bgCreateThree)) {
       // let background create Ratis pipelines.
@@ -287,16 +279,17 @@ public class ContainerStateManager {
       } catch (IOException e) {
 
         if (pipelines.isEmpty()) {
-          throw new IOException("Could not allocate container. Cannot get any" +
-              " matching pipeline for Type:" + type +
-              ", Factor:" + replicationFactor + ", State:PipelineState.OPEN", e);
+          throw new IOException("Could not allocate container. Cannot get any"
+              + " matching pipeline for Type:" + type + ", Factor:"
+              + replicationFactor + ", State:PipelineState.OPEN", e);
         }
-        pipeline = pipelines.get((int) containerCount.get() % pipelines.size());
+        pipeline =
+            pipelines.get((int) containerCount.get() % pipelines.size());
       }
     }
 
     synchronized (pipeline) {
-      return allocateContainer(storageClassName, pipelineManager,
+      return allocateContainer(storageClass, pipelineManager,
           owner, pipeline);
     }
   }
@@ -314,7 +307,7 @@ public class ContainerStateManager {
    * @throws IOException on Failure.
    */
   ContainerInfo allocateContainer(
-      String storageClassName,
+      StorageClass storageClass,
       final PipelineManager pipelineManager,
       final String owner,
       Pipeline pipeline) throws IOException {
@@ -332,7 +325,7 @@ public class ContainerStateManager {
         .setOwner(owner)
         .setContainerID(containerID)
         .setDeleteTransactionId(0)
-        .setStorageClass(storageClassName)
+        .setStorageClass(storageClass)
         .build();
     addContainerInfo(containerID, containerInfo, pipelineManager, pipeline);
     if (LOG.isTraceEnabled()) {
@@ -408,8 +401,7 @@ public class ContainerStateManager {
    * @return ContainerInfo, null if there is no match found.
    */
   ContainerInfo getMatchingContainer(
-      String storageClass,
-      long size,
+      StorageClass storageClass, long size, String owner,
       PipelineID pipelineID, NavigableSet<ContainerID> containerIDs) {
     if (containerIDs.isEmpty()) {
       return null;
@@ -417,7 +409,8 @@ public class ContainerStateManager {
 
     // Get the last used container and find container above the last used
     // container ID.
-    final ContainerState key = new ContainerState(storageClass, pipelineID);
+    final ContainerState key = new ContainerState(storageClass, owner,
+        pipelineID);
     final ContainerID lastID =
         lastUsedMap.getOrDefault(key, containerIDs.first());
 
@@ -429,7 +422,8 @@ public class ContainerStateManager {
     }
 
     ContainerInfo selectedContainer =
-        findContainerWithSpace(storageClass, size, resultSet, pipelineID);
+        findContainerWithSpace(
+            storageClass, size, resultSet, pipelineID);
     if (selectedContainer == null) {
 
       // If we did not find any space in the tailSet, we need to look for
@@ -442,14 +436,15 @@ public class ContainerStateManager {
 
       resultSet = containerIDs.headSet(lastID, true);
       selectedContainer =
-          findContainerWithSpace(storageClass, size, resultSet, pipelineID);
+          findContainerWithSpace(storageClass,
+              size, resultSet, pipelineID);
     }
 
     return selectedContainer;
   }
 
   private ContainerInfo findContainerWithSpace(
-      String storageClassName,
+      StorageClass storageClass,
       final long size,
       final NavigableSet<ContainerID> searchSet,
       final PipelineID pipelineID) {
@@ -458,7 +453,8 @@ public class ContainerStateManager {
       for (ContainerID id : searchSet) {
         final ContainerInfo containerInfo = containers.getContainerInfo(id);
         if (containerInfo.getUsedBytes() + size <= this.containerSize
-            && storageClassName.equals(containerInfo.getStorageClass())) {
+            && storageClass.getName().equals(
+                containerInfo.getStorageClass())) {
           containerInfo.updateLastUsedTime();
           return containerInfo;
         }
@@ -498,15 +494,15 @@ public class ContainerStateManager {
    * Returns a set of ContainerIDs that match the Container.
    *
    * @param owner  Owner of the Containers.
-   * @param storageClassName - Name of the storage class
+   * @param storageClass - The storage class
    * @param state - Current State, like Open, Close etc.
    * @return Set of containers that match the specific query parameters.
    */
   NavigableSet<ContainerID> getMatchingContainerIDs(final String owner,
-      final String storageClassName,
+      final StorageClass storageClass,
       final LifeCycleState state) {
     return containers.getMatchingContainerIDs(state, owner,
-        storageClassName);
+        storageClass);
   }
 
   /**
@@ -569,10 +565,11 @@ public class ContainerStateManager {
    * @param pipelineID
    * @param containerID
    * @param owner
+   * @param storageClass
    */
   public synchronized void updateLastUsedMap(PipelineID pipelineID,
-      ContainerID containerID, String owner) {
-    lastUsedMap.put(new ContainerState(owner, pipelineID),
+      ContainerID containerID, String owner, StorageClass storageClass) {
+    lastUsedMap.put(new ContainerState(storageClass, owner, pipelineID),
         containerID);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -35,9 +35,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.apache.hadoop.hdds.StaticStorageClassRegistry;
 import org.apache.hadoop.hdds.StorageClass;
-import org.apache.hadoop.hdds.StorageClassRegistry;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigType;
@@ -141,9 +139,6 @@ public class ReplicationManager
    * Used for check datanode state.
    */
   private final NodeManager nodeManager;
-
-  private StorageClassRegistry storageClassRegistry =
-      new StaticStorageClassRegistry();
 
   /**
    * Constructs ReplicationManager instance with the given configuration.
@@ -271,8 +266,7 @@ public class ReplicationManager
           .getContainerReplicas(container.containerID());
       final LifeCycleState state = container.getState();
 
-      StorageClass storageClass =
-          storageClassRegistry.getStorageClass(container.getStorageClass());
+      StorageClass storageClass = container.getStorageClass();
 
       /*
        * We don't take any action if the container is in OPEN state and

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerQueryKey.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerQueryKey.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.scm.container.states;
 
+import org.apache.hadoop.hdds.StorageClass;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -29,7 +30,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 public class ContainerQueryKey {
   private final HddsProtos.LifeCycleState state;
   private final String owner;
-  private final String storageClass;
+  private final StorageClass storageClass;
 
   @Override
   public boolean equals(Object o) {
@@ -46,7 +47,7 @@ public class ContainerQueryKey {
     return new EqualsBuilder()
         .append(getState(), that.getState())
         .append(getOwner(), that.getOwner())
-        .append(getStorageClass(), that.getStorageClass())
+        .append(getStorageClass().getName(), that.getStorageClass().getName())
         .isEquals();
   }
 
@@ -67,7 +68,7 @@ public class ContainerQueryKey {
    * @param storageClass - StorageClass
    */
   public ContainerQueryKey(HddsProtos.LifeCycleState state, String owner,
-      String storageClass) {
+      StorageClass storageClass) {
     this.state = state;
     this.owner = owner;
     this.storageClass = storageClass;
@@ -92,7 +93,7 @@ public class ContainerQueryKey {
   /**
    * Returns the storageClass of this specific container.
    */
-  public String getStorageClass() {
+  public StorageClass getStorageClass() {
     return storageClass;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerState.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerState.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.scm.container.states;
 
+import org.apache.hadoop.hdds.StorageClass;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -27,22 +28,25 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
  * Class that acts as the container state.
  */
 public class ContainerState {
-  private final String storageClass;
+  private final StorageClass storageClass;
   private final PipelineID pipelineID;
+  private final String owner;
 
   /**
    * Constructs a Container Key.
    *
-   * @param owner      - Container Owners
+   * @param storageClass - storageClass
    * @param pipelineID - ID of the pipeline
    */
-  public ContainerState(String storageClass, PipelineID pipelineID) {
+  public ContainerState(
+      StorageClass storageClass, String owner, PipelineID pipelineID) {
+    this.owner = owner;
     this.pipelineID = pipelineID;
     this.storageClass = storageClass;
   }
 
   public String getOwner() {
-    return storageClass;
+    return this.owner;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.apache.hadoop.hdds.StorageClass;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -81,7 +82,7 @@ public class ContainerStateMap {
 
   private final ContainerAttribute<LifeCycleState> lifeCycleStateMap;
   private final ContainerAttribute<String> ownerMap;
-  private final ContainerAttribute<String> storageClassMap;
+  private final ContainerAttribute<StorageClass> storageClassMap;
   private final Map<ContainerID, ContainerInfo> containerMap;
   private final Map<ContainerID, Set<ContainerReplica>> replicaMap;
   private final Map<ContainerQueryKey, NavigableSet<ContainerID>> resultCache;
@@ -351,11 +352,11 @@ public class ContainerStateMap {
   /**
    * Returns Containers by replication factor.
    *
-   * @param factor - Replication Factor.
+   * @param storageClass - StorageClass.
    * @return NavigableSet.
    */
   NavigableSet<ContainerID> getContainerIDsByStorageClass(
-      final String storageClass) {
+      final StorageClass storageClass) {
     Preconditions.checkNotNull(storageClass);
     lock.readLock().lock();
     try {
@@ -391,7 +392,8 @@ public class ContainerStateMap {
    * @return ContainerInfo or Null if not container satisfies the criteria.
    */
   public NavigableSet<ContainerID> getMatchingContainerIDs(
-      final LifeCycleState state, final String owner, String storageClass) {
+      final LifeCycleState state, final String owner,
+      StorageClass storageClass) {
 
     Preconditions.checkNotNull(state, "State cannot be null");
     Preconditions.checkNotNull(owner, "Owner cannot be null");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/ContainerInfoCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/ContainerInfoCodec.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.metadata;
 
 import java.io.IOException;
 
+import org.apache.hadoop.hdds.StorageClass;
 import org.apache.hadoop.hdds.StorageClassConverter;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerInfoProto;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -40,7 +41,7 @@ public class ContainerInfoCodec implements Codec<ContainerInfo> {
     ContainerInfo info = ContainerInfo.fromProtobuf(
         ContainerInfoProto.PARSER.parseFrom(rawData));
     if (info.getStorageClass() == null) {
-      final String calculatedStorageClass =
+      StorageClass calculatedStorageClass =
           StorageClassConverter.convert(null, info.getReplicationFactor(),
               info.getReplicationType());
       info.setStorageClass(calculatedStorageClass);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -188,7 +188,8 @@ public class SCMClientProtocolServer implements
     getScm().checkAdminAccess(getRpcRemoteUsername());
 
     final ContainerInfo container = scm.getContainerManager()
-        .allocateContainer(storageClass, owner);
+        .allocateContainer(scm.getStorageClassRegistry()
+            .getStorageClass(storageClass), owner);
     final Pipeline pipeline = scm.getPipelineManager()
         .getPipeline(container.getPipelineID());
     return new ContainerWithPipeline(container, pipeline);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -37,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsUtils;
+import org.apache.hadoop.hdds.StaticStorageClassRegistry;
+import org.apache.hadoop.hdds.StorageClassRegistry;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -194,6 +196,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   private SCMContainerMetrics scmContainerMetrics;
   private SCMContainerPlacementMetrics placementMetrics;
   private MetricsSystem ms;
+  // TODO(baoloongmao): assign this froms configuration
+  private StorageClassRegistry storageClassRegistry =
+      new StaticStorageClassRegistry();
 
   /**
    *  Network topology Map.
@@ -1131,5 +1136,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       map.put(entry.getKey(), entry.getValue().getRight());
     }
     return map;
+  }
+
+  public StorageClassRegistry getStorageClassRegistry() {
+    return storageClassRegistry;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.apache.hadoop.hdds.StaticStorageClassRegistry;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
@@ -411,7 +412,7 @@ public final class TestUtils {
       allocateContainer(ContainerManager containerManager)
       throws IOException {
     return containerManager
-        .allocateContainer("STANDARD", "root");
+        .allocateContainer(StaticStorageClassRegistry.STANDARD, "root");
 
   }
 
@@ -491,7 +492,7 @@ public final class TestUtils {
         .setReplicationType(HddsProtos.ReplicationType.RATIS)
         .setReplicationFactor(HddsProtos.ReplicationFactor.THREE)
         .setState(state)
-        .setStorageClass("STANDARD")
+        .setStorageClass(StaticStorageClassRegistry.STANDARD)
         .setSequenceId(10000L)
         .setOwner("TEST")
         .build();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import org.apache.hadoop.hdds.StorageClass;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
@@ -368,16 +369,16 @@ public class OzoneBucket extends WithMetadata {
    * Creates a new key in the bucket.
    * @param key Name of the key to be created.
    * @param size Size of the data the key will point to.
-   * @param storageClass storage class name
+   * @param storageClassName storage class name
    * @return OzoneOutputStream to which the data has to be written.
    * @throws IOException
    */
   public OzoneOutputStream createKey(String key, long size,
-                                     String sc,
+                                     String storageClassName,
                                      Map<String, String> keyMetadata)
       throws IOException {
     return proxy
-        .createKey(volumeName, name, key, size, sc, keyMetadata);
+        .createKey(volumeName, name, key, size, storageClassName, keyMetadata);
   }
 
   /**
@@ -459,8 +460,7 @@ public class OzoneBucket extends WithMetadata {
   /**
    * Initiate multipart upload for a specified key.
    * @param keyName
-   * @param type
-   * @param factor
+   * @param sc
    * @return OmMultipartInfo
    * @throws IOException
    */
@@ -597,10 +597,10 @@ public class OzoneBucket extends WithMetadata {
    *                     invalid arguments
    */
   public OzoneOutputStream createFile(String keyName, long size,
-      String sc, boolean overWrite,
+      StorageClass sc, boolean overWrite,
       boolean recursive) throws IOException {
     return proxy
-        .createFile(volumeName, name, keyName, size, sc, overWrite,
+        .createFile(volumeName, name, keyName, size, sc.getName(), overWrite,
             recursive);
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -421,7 +421,8 @@ public final class OmKeyInfo extends WithObjectID {
       if (keyInfo.hasType()) {
         type = keyInfo.getType();
       }
-      storageClass = StorageClassConverter.convert(null, factor, type);
+      storageClass =
+          StorageClassConverter.convert(null, factor, type).getName();
     }
 
     Builder builder = new Builder()

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartKeyInfo.java
@@ -152,7 +152,7 @@ public class OmMultipartKeyInfo extends WithObjectID {
     } else {
       storageClass = StorageClassConverter.convert(null,
           multipartKeyInfo.getFactor(),
-          multipartKeyInfo.getType());
+          multipartKeyInfo.getType()).getName();
     }
     return new OmMultipartKeyInfo(multipartKeyInfo.getUploadID(),
         multipartKeyInfo.getCreationTime(), storageClass, list,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -25,6 +25,7 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.hdds.StorageClass;
 import org.apache.hadoop.hdds.StorageClassConverter;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -100,9 +101,9 @@ public class TestContainerStateManagerIntegration {
         .allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)),
+                SCMTestUtils.getReplicationType(conf)).getName(),
             OzoneConsts.OZONE);
-    String storageClass =
+    StorageClass storageClass =
         StorageClassConverter.convert(null,
             container1.getPipeline().getFactor(),
             container1.getPipeline().getType());
@@ -123,7 +124,8 @@ public class TestContainerStateManagerIntegration {
         .allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)), OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)).getName(),
+            OzoneConsts.OZONE);
     int numContainers = containerStateManager
         .getMatchingContainerIDs(OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
@@ -143,8 +145,9 @@ public class TestContainerStateManagerIntegration {
         .allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)), OzoneConsts.OZONE);
-    String storageClass =
+                SCMTestUtils.getReplicationType(conf)).getName(),
+            OzoneConsts.OZONE);
+    StorageClass storageClass =
         StorageClassConverter.convert(null,
             container1.getPipeline().getFactor(),
             container1.getPipeline().getType());
@@ -158,7 +161,8 @@ public class TestContainerStateManagerIntegration {
         .allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)), newContainerOwner);
+                SCMTestUtils.getReplicationType(conf)).getName(),
+            newContainerOwner);
     ContainerInfo info2 = containerManager
         .getMatchingContainer(OzoneConsts.GB * 3, newContainerOwner,
             storageClass, container1.getPipeline());
@@ -178,7 +182,8 @@ public class TestContainerStateManagerIntegration {
           .allocateContainer(
               StorageClassConverter.convert(null,
                   SCMTestUtils.getReplicationFactor(conf),
-                  SCMTestUtils.getReplicationType(conf)), OzoneConsts.OZONE);
+                  SCMTestUtils.getReplicationType(conf)).getName(),
+              OzoneConsts.OZONE);
       if (i >= 5) {
         scm.getContainerManager().updateContainerState(container
                 .getContainerInfo().containerID(),
@@ -226,13 +231,14 @@ public class TestContainerStateManagerIntegration {
         allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)), OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)).getName(),
+            OzoneConsts.OZONE);
     cid = container1.getContainerInfo().getContainerID();
 
     // each getMatchingContainer call allocates a container in the
     // pipeline till the pipeline has numContainerPerOwnerInPipeline number of
     // containers.
-    String storageClass =
+    StorageClass storageClass =
         StorageClassConverter.convert(null,
             container1.getPipeline().getFactor(),
             container1.getPipeline().getType());
@@ -260,10 +266,11 @@ public class TestContainerStateManagerIntegration {
         allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)), OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)).getName(),
+            OzoneConsts.OZONE);
     cid = container1.getContainerInfo().getContainerID();
 
-    String storageClass =
+    StorageClass storageClass =
         StorageClassConverter.convert(null,
             container1.getPipeline().getFactor(),
             container1.getPipeline().getType());
@@ -297,10 +304,11 @@ public class TestContainerStateManagerIntegration {
         allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)), OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)).getName(),
+            OzoneConsts.OZONE);
     cid = container1.getContainerInfo().getContainerID();
 
-    String storageClass =
+    StorageClass storageClass =
         StorageClassConverter.convert(null,
             container1.getPipeline().getFactor(),
             container1.getPipeline().getType());
@@ -329,11 +337,12 @@ public class TestContainerStateManagerIntegration {
         allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)), OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)).getName(),
+            OzoneConsts.OZONE);
     Map<Long, Long> container2MatchedCount = new ConcurrentHashMap<>();
 
     // allocate blocks using multiple threads
-    String storageClass =
+    StorageClass storageClass =
         StorageClassConverter.convert(null,
             container1.getPipeline().getFactor(),
             container1.getPipeline().getType());
@@ -386,7 +395,8 @@ public class TestContainerStateManagerIntegration {
         .allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)), OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)).getName(),
+            OzoneConsts.OZONE);
     containers = containerStateManager.getMatchingContainerIDs(
         OzoneConsts.OZONE,
         StorageClassConverter.convert(null,
@@ -445,7 +455,8 @@ public class TestContainerStateManagerIntegration {
         .allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)), OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)).getName(),
+            OzoneConsts.OZONE);
     containerManager
         .updateContainerState(container3.getContainerInfo().containerID(),
             HddsProtos.LifeCycleEvent.FINALIZE);
@@ -485,7 +496,8 @@ public class TestContainerStateManagerIntegration {
         .allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)), OzoneConsts.OZONE);
+                SCMTestUtils.getReplicationType(conf)).getName(),
+            OzoneConsts.OZONE);
 
     ContainerID id = container.getContainerInfo().containerID();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
@@ -84,7 +84,7 @@ public class TestSCMContainerManagerMetrics {
         "NumSuccessfulCreateContainers", metrics);
 
     ContainerInfo containerInfo = containerManager.allocateContainer(
-        StaticStorageClassRegistry.REDUCED_REDUNDANCY.getName(), OzoneConsts.OZONE);
+        StaticStorageClassRegistry.REDUCED_REDUNDANCY, OzoneConsts.OZONE);
 
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
     Assert.assertEquals(getLongCounter("NumSuccessfulCreateContainers",
@@ -92,7 +92,7 @@ public class TestSCMContainerManagerMetrics {
 
     try {
       containerManager.allocateContainer(
-          StaticStorageClassRegistry.STANDARD.getName(), OzoneConsts.OZONE);
+          StaticStorageClassRegistry.STANDARD, OzoneConsts.OZONE);
       fail("testContainerOpsMetrics failed");
     } catch (IOException ex) {
       // Here it should fail, so it should have the old metric value.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
@@ -72,7 +72,7 @@ public class TestNode2PipelineMap {
     containerManager = scm.getContainerManager();
     pipelineManager = scm.getPipelineManager();
     ContainerInfo containerInfo = containerManager.allocateContainer(
-        StaticStorageClassRegistry.STANDARD.getName(), "testOwner");
+        StaticStorageClassRegistry.STANDARD, "testOwner");
     ratisContainer = new ContainerWithPipeline(containerInfo,
         pipelineManager.getPipeline(containerInfo.getPipelineID()));
     pipelineManager = scm.getPipelineManager();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -97,7 +97,7 @@ public class TestPipelineClose {
     pipelineManager = scm.getPipelineManager();
     ContainerInfo containerInfo = containerManager
         .allocateContainer(
-            StaticStorageClassRegistry.STANDARD.getName(), "testOwner");
+            StaticStorageClassRegistry.STANDARD, "testOwner");
     ratisContainer = new ContainerWithPipeline(containerInfo,
         pipelineManager.getPipeline(containerInfo.getPipelineID()));
     pipelineManager = scm.getPipelineManager();
@@ -210,7 +210,7 @@ public class TestPipelineClose {
 
     ContainerInfo containerInfo = containerManager
         .allocateContainer(
-            StaticStorageClassRegistry.STANDARD.getName(), "testOwner");
+            StaticStorageClassRegistry.STANDARD, "testOwner");
     ContainerWithPipeline containerWithPipeline =
         new ContainerWithPipeline(containerInfo,
             pipelineManager.getPipeline(containerInfo.getPipelineID()));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
@@ -75,11 +75,11 @@ public class TestSCMRestart {
     pipelineManager = scm.getPipelineManager();
     ratisPipeline1 = pipelineManager.getPipeline(
         containerManager.allocateContainer(
-            StaticStorageClassRegistry.STANDARD.getName(), "Owner1")
+            StaticStorageClassRegistry.STANDARD, "Owner1")
             .getPipelineID());
     ratisPipeline2 = pipelineManager.getPipeline(
         containerManager.allocateContainer(
-            StaticStorageClassRegistry.REDUCED_REDUNDANCY.getName(), "Owner2")
+            StaticStorageClassRegistry.REDUCED_REDUNDANCY, "Owner2")
             .getPipelineID());
     // At this stage, there should be 2 pipeline one with 1 open container
     // each. Try restarting the SCM and then discover that pipeline are in
@@ -116,7 +116,7 @@ public class TestSCMRestart {
     // as was before restart
     ContainerInfo containerInfo = newContainerManager
         .allocateContainer(
-            StaticStorageClassRegistry.STANDARD.getName(), "Owner1");
+            StaticStorageClassRegistry.STANDARD, "Owner1");
     Assert.assertEquals(containerInfo.getPipelineID(), ratisPipeline1.getId());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -192,7 +192,7 @@ public class TestStorageContainerManager {
             .allocateContainer(
                 StorageClassConverter.convert(null,
                     HddsProtos.ReplicationFactor.ONE,
-                    SCMTestUtils.getReplicationType(ozoneConf)),
+                    SCMTestUtils.getReplicationType(ozoneConf)).getName(),
                 OzoneConsts.OZONE);
         if (expectPermissionDenied) {
           fail("Operation should fail, expecting an IOException here.");
@@ -208,7 +208,7 @@ public class TestStorageContainerManager {
             .allocateContainer(
                 StorageClassConverter.convert(null,
                     HddsProtos.ReplicationFactor.ONE,
-                    SCMTestUtils.getReplicationType(ozoneConf)),
+                    SCMTestUtils.getReplicationType(ozoneConf)).getName(),
                 OzoneConsts.OZONE);
         if (expectPermissionDenied) {
           fail("Operation should fail, expecting an IOException here.");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -2566,7 +2566,7 @@ public abstract class TestOzoneRpcClientAbstract {
       ReplicationType replicationType, ReplicationFactor replicationFactor)
       throws Exception {
     String storageClass = StorageClassConverter.convert(
-        null, replicationFactor, replicationType);
+        null, replicationFactor, replicationType).getName();
     OmMultipartInfo multipartInfo = bucket.initiateMultipartUpload(keyName,
         storageClass);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestHelper.java
@@ -105,7 +105,7 @@ public final class TestHelper {
             org.apache.hadoop.hdds.client.ReplicationFactor.ONE :
             org.apache.hadoop.hdds.client.ReplicationFactor.THREE;
     String storageClass =
-        StorageClassConverter.convert(null, factor, type);
+        StorageClassConverter.convert(null, factor, type).getName();
     return objectStore.getVolume(volumeName).getBucket(bucketName)
         .createKey(keyName, size, storageClass, new HashMap<>());
   }
@@ -116,7 +116,7 @@ public final class TestHelper {
       ObjectStore objectStore, String volumeName, String bucketName)
       throws Exception {
     String storageClass =
-        StorageClassConverter.convert(null, factor, type);
+        StorageClassConverter.convert(null, factor, type).getName();
     return objectStore.getVolume(volumeName).getBucket(bucketName)
         .createKey(keyName, size, storageClass, new HashMap<>());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -266,7 +266,7 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
 
     OzoneOutputStream ozoneOutputStream = ozoneBucket.createFile(keyName,
         data.length(),
-        StaticStorageClassRegistry.REDUCED_REDUNDANCY.getName(),
+        StaticStorageClassRegistry.REDUCED_REDUNDANCY,
         overwrite, recursive);
 
     ozoneOutputStream.write(data.getBytes(), 0, data.length());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
@@ -128,7 +128,7 @@ public class TestReconAsPassiveScm {
     ContainerManager reconContainerManager = reconScm.getContainerManager();
     ContainerInfo containerInfo =
         scmContainerManager.allocateContainer(
-            StaticStorageClassRegistry.REDUCED_REDUNDANCY.getName(),
+            StaticStorageClassRegistry.REDUCED_REDUNDANCY,
             "test");
     long containerID = containerInfo.getContainerID();
     Pipeline pipeline =
@@ -169,7 +169,7 @@ public class TestReconAsPassiveScm {
     // Create container in SCM.
     ContainerInfo containerInfo =
         scmContainerManager.allocateContainer(
-            StaticStorageClassRegistry.REDUCED_REDUNDANCY.getName(), "test");
+            StaticStorageClassRegistry.REDUCED_REDUNDANCY, "test");
     long containerID = containerInfo.getContainerID();
     PipelineManager scmPipelineManager = scm.getPipelineManager();
     Pipeline pipeline =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
@@ -106,7 +106,7 @@ public class TestReconTasks {
         (ReconContainerManager) reconScm.getContainerManager();
     ContainerInfo containerInfo =
         scmContainerManager.allocateContainer(
-            StaticStorageClassRegistry.REDUCED_REDUNDANCY.getName(), "test");
+            StaticStorageClassRegistry.REDUCED_REDUNDANCY, "test");
     long containerID = containerInfo.getContainerID();
     Pipeline pipeline =
         scmPipelineManager.getPipeline(containerInfo.getPipelineID());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
@@ -78,7 +78,7 @@ public class TestAllocateContainer {
             OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)));
+                SCMTestUtils.getReplicationType(conf)).getName());
     Assert.assertNotNull(container);
     Assert.assertNotNull(container.getPipeline().getFirstNode());
 
@@ -91,6 +91,6 @@ public class TestAllocateContainer {
         null,
         StorageClassConverter.convert(null,
             SCMTestUtils.getReplicationFactor(conf),
-            SCMTestUtils.getReplicationType(conf)));
+            SCMTestUtils.getReplicationType(conf)).getName());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
@@ -92,7 +92,7 @@ public class TestContainerSmallFile {
             OzoneConsts.OZONE,
             StorageClassConverter.convert(
                 null, HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(ozoneConfig)));
+                SCMTestUtils.getReplicationType(ozoneConfig)).getName());
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,
@@ -116,7 +116,7 @@ public class TestContainerSmallFile {
             OzoneConsts.OZONE,
             StorageClassConverter.convert(
                 null, HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(ozoneConfig)));
+                SCMTestUtils.getReplicationType(ozoneConfig)).getName());
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,
@@ -141,7 +141,7 @@ public class TestContainerSmallFile {
             OzoneConsts.OZONE,
             StorageClassConverter.convert(
                 null, HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(ozoneConfig)));
+                SCMTestUtils.getReplicationType(ozoneConfig)).getName());
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());
     ContainerProtocolCalls.createContainer(client,
@@ -169,7 +169,7 @@ public class TestContainerSmallFile {
             OzoneConsts.OZONE,
             StorageClassConverter.convert(
                 null, HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(ozoneConfig))
+                SCMTestUtils.getReplicationType(ozoneConfig)).getName()
         );
     XceiverClientSpi client = xceiverClientManager
         .acquireClient(container.getPipeline());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestGetCommittedBlockLengthAndPutKey.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestGetCommittedBlockLengthAndPutKey.java
@@ -97,7 +97,7 @@ public class TestGetCommittedBlockLengthAndPutKey {
             StorageClassConverter.convert(
                             null,
                 HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(ozoneConfig))
+                SCMTestUtils.getReplicationType(ozoneConfig)).getName()
             );
     long containerID = container.getContainerInfo().getContainerID();
     Pipeline pipeline = container.getPipeline();
@@ -135,7 +135,7 @@ public class TestGetCommittedBlockLengthAndPutKey {
             StorageClassConverter.convert(
                 null,
                 HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(ozoneConfig))
+                SCMTestUtils.getReplicationType(ozoneConfig)).getName()
         );
     long containerID = container.getContainerInfo().getContainerID();
     XceiverClientSpi client = xceiverClientManager

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMMXBean.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.hadoop.hdds.StaticStorageClassRegistry;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -151,7 +152,7 @@ public class TestSCMMXBean {
     List<ContainerInfo> containerInfoList = new ArrayList<>();
     for (int i=0; i < 10; i++) {
       containerInfoList.add(scmContainerManager.allocateContainer(
-          "LEGACY",
+          StaticStorageClassRegistry.LEGACY,
           UUID.randomUUID().toString()));
     }
     long containerID;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
@@ -96,7 +96,7 @@ public class TestXceiverClientManager {
             OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)));
+                SCMTestUtils.getReplicationType(conf)).getName());
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
@@ -105,7 +105,7 @@ public class TestXceiverClientManager {
         .allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)),
+                SCMTestUtils.getReplicationType(conf)).getName(),
             OzoneConsts.OZONE);
     XceiverClientSpi client2 = clientManager
         .acquireClient(container2.getPipeline());
@@ -139,7 +139,7 @@ public class TestXceiverClientManager {
             OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
                 HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(conf)));
+                SCMTestUtils.getReplicationType(conf)).getName());
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
@@ -150,7 +150,7 @@ public class TestXceiverClientManager {
         storageContainerLocationClient.allocateContainer(
             StorageClassConverter.convert(null,
                 HddsProtos.ReplicationFactor.ONE,
-                SCMTestUtils.getReplicationType(conf)),
+                SCMTestUtils.getReplicationType(conf)).getName(),
             OzoneConsts.OZONE);
     XceiverClientSpi client2 = clientManager
         .acquireClient(container2.getPipeline());
@@ -201,7 +201,7 @@ public class TestXceiverClientManager {
             OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)));
+                SCMTestUtils.getReplicationType(conf)).getName());
     XceiverClientSpi client1 = clientManager
         .acquireClient(container1.getPipeline());
     Assert.assertEquals(1, client1.getRefcount());
@@ -213,7 +213,7 @@ public class TestXceiverClientManager {
         storageContainerLocationClient.allocateContainer(
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)),
+                SCMTestUtils.getReplicationType(conf)).getName(),
             OzoneConsts.OZONE);
     XceiverClientSpi client2 = clientManager
         .acquireClient(container2.getPipeline());
@@ -256,7 +256,7 @@ public class TestXceiverClientManager {
             OzoneConsts.OZONE,
             StorageClassConverter.convert(null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)));
+                SCMTestUtils.getReplicationType(conf)).getName());
     XceiverClientSpi client1 =
         clientManager.acquireClient(container1.getPipeline());
     clientManager.acquireClient(container1.getPipeline());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientMetrics.java
@@ -101,7 +101,7 @@ public class TestXceiverClientMetrics {
             StorageClassConverter.convert(
                 null,
                 SCMTestUtils.getReplicationFactor(conf),
-                SCMTestUtils.getReplicationType(conf)));
+                SCMTestUtils.getReplicationType(conf)).getName());
     XceiverClientSpi client = clientManager
         .acquireClient(container.getPipeline());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
@@ -108,7 +108,7 @@ public class TestSCMPipelineMetrics {
     AllocatedBlock block =
         cluster.getStorageContainerManager().getScmBlockManager()
             .allocateBlock(5,
-                StaticStorageClassRegistry.REDUCED_REDUNDANCY.getName(),
+                StaticStorageClassRegistry.REDUCED_REDUNDANCY,
                 "Test", new ExcludeList());
     MetricsRecordBuilder metrics =
         getMetrics(SCMPipelineMetrics.class.getSimpleName());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1353,7 +1353,7 @@ public class KeyManagerImpl implements KeyManager {
             } else {
               storageClass = StorageClassConverter.convert(null,
                   partKeyInfo.getPartKeyInfo().getFactor(),
-                  partKeyInfo.getPartKeyInfo().getType());
+                  partKeyInfo.getPartKeyInfo().getType()).getName();
             }
             count++;
           }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -195,7 +195,7 @@ public final class TestOMRequestUtils {
         .setModificationTime(Time.now())
         .setDataSize(1000L)
         .setStorageClass(StorageClassConverter.convert(
-        null, replicationFactor, replicationType))
+        null, replicationFactor, replicationType).getName())
         .build();
   }
 
@@ -225,7 +225,7 @@ public final class TestOMRequestUtils {
         .setModificationTime(Time.now())
         .setDataSize(1000L)
         .setStorageClass(StorageClassConverter.convert(
-            null, replicationFactor, replicationType))
+            null, replicationFactor, replicationType).getName())
         .setObjectID(objectID)
         .setUpdateID(objectID)
         .build();

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -203,13 +203,13 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
           || replication == ReplicationFactor.THREE.getValue()) {
         ReplicationFactor clientReplication = ReplicationFactor
             .valueOf(replication);
-        String sc = StorageClassConverter.convert(null, clientReplication,
+        StorageClass sc = StorageClassConverter.convert(null, clientReplication,
             storageClass.getOpenStateConfiguration().getReplicationType());
         ozoneOutputStream = bucket.createFile(key, 0, sc, overWrite,
             recursive);
       } else {
         ozoneOutputStream = bucket.createFile(key, 0,
-            storageClass.getName(), overWrite, recursive);
+            storageClass, overWrite, recursive);
       }
       return new OzoneFSOutputStream(ozoneOutputStream.getOutputStream());
     } catch (OMException ex) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -322,13 +322,13 @@ public class BasicRootedOzoneClientAdapterImpl
           || replication == ReplicationFactor.THREE.getValue()) {
         ReplicationFactor clientReplication = ReplicationFactor
             .valueOf(replication);
-        String sc = StorageClassConverter
+        StorageClass sc = StorageClassConverter
             .convert(null, clientReplication,
                 storageClass.getOpenStateConfiguration().getReplicationType());
         ozoneOutputStream = bucket.createFile(key, 0, sc, overWrite,
             recursive);
       } else {
-        ozoneOutputStream = bucket.createFile(key, 0, storageClass.getName(),
+        ozoneOutputStream = bucket.createFile(key, 0, storageClass,
             overWrite, recursive);
       }
       return new OzoneFSOutputStream(ozoneOutputStream.getOutputStream());

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -86,7 +86,7 @@ public class OzoneBucketStub extends OzoneBucket {
 
   @Override
   public OzoneOutputStream createKey(String key, long size,
-                                    String storageClass,
+                                    String storageClassName,
                                     Map<String, String> metadata)
       throws IOException {
     ByteArrayOutputStream byteArrayOutputStream =
@@ -102,7 +102,7 @@ public class OzoneBucketStub extends OzoneBucket {
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
                 new ArrayList<>(), metadata, null,
-                storageClass
+                storageClassName
             ));
             super.close();
           }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
@@ -108,7 +108,7 @@ public class OmKeyGenerator extends BaseFreonGenerator
         .setBucketName(bucketName)
         .setVolumeName(volumeName)
         .setStorageClass(StorageClassConverter.convert(
-            null, factor, ReplicationType.RATIS))
+            null, factor, ReplicationType.RATIS).getName())
         .setKeyName(generateObjectName(counter))
         .setLocationInfoList(new ArrayList<>())
         .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -114,7 +114,7 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
     timer.time(() -> {
       try (OutputStream stream = bucket.createKey(key, keySize,
           StorageClassConverter.convert(
-              null, factor, ReplicationType.RATIS), metadata)) {
+              null, factor, ReplicationType.RATIS).getName(), metadata)) {
         contentGenerator.write(stream);
         stream.flush();
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkContainerStateMap.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkContainerStateMap.java
@@ -195,6 +195,6 @@ public class BenchMarkContainerStateMap {
     }
     bh.consume(state.stateMap
         .getMatchingContainerIDs(OPEN, OzoneConsts.OZONE,
-            StaticStorageClassRegistry.LEGACY.getName()));
+            StaticStorageClassRegistry.LEGACY));
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkSCM.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkSCM.java
@@ -120,7 +120,7 @@ public class BenchMarkSCM {
   public void allocateBlockBenchMark(BenchMarkSCM state,
       Blackhole bh) throws IOException {
     state.blockManager
-        .allocateBlock(50, StaticStorageClassRegistry.STANDARD.getName(),
+        .allocateBlock(50, StaticStorageClassRegistry.STANDARD,
             "Genesis", new ExcludeList());
   }
 }


### PR DESCRIPTION
Pervious, we use string stand for StorageClass everywhere, we have to use StorageClassRegister to convert it to StorageClass class, it is inconvenient